### PR TITLE
fix: release workflow and CLI version issues

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -29,11 +29,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
       
-      - name: Run tests
-        run: npm test
-      
       - name: Build package
         run: npm run build:clean
+      
+      - name: Run tests
+        run: npm test
       
       - name: Extract version info
         id: version

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -100,7 +100,8 @@ NEW_VERSION=${NEW_VERSION#v} # Remove 'v' prefix if present
 
 # Update version in CLI file
 print_step "Updating version in CLI..."
-sed -i "s/\.version('[^']*')/\.version('$NEW_VERSION')/" src/cli/index.ts
+# Use a more robust sed command that handles special characters
+sed -i "s/\.version('[^']*')/\.version('${NEW_VERSION//\//\\/}')/" src/cli/index.ts
 
 # Rebuild with new version
 print_step "Rebuilding with new version..."

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -11,7 +11,7 @@ const program = new Command();
 program
   .name('claude-gwt')
   .description('Git Worktree Manager with Claude Code Orchestration')
-  .version('0.1.2');
+  .version('0.2.2');
 
 // Main command
 program


### PR DESCRIPTION
## Summary
- Fixes the release workflow that was failing for v0.2.1 and v0.2.2
- Updates hardcoded CLI version to current version
- Makes release script more robust

## Changes
1. **Fix release workflow order**: Build before running tests
   - Integration tests require dist/ directory to exist
   - Was causing MODULE_NOT_FOUND errors in release workflow

2. **Fix sed command**: Handle special characters in version strings
   - Previous sed command could fail with certain version formats
   - Now properly escapes forward slashes

3. **Update CLI version**: From hardcoded 0.1.2 to current 0.2.2
   - The CLI was showing wrong version with --version flag

## Test Results
All 468 tests passing locally with these changes.

## Impact
This will ensure future releases work smoothly through GitHub Actions without manual intervention.

🤖 Generated with [Claude Code](https://claude.ai/code)