### PR TITLE
fix: Build before tests in auto-beta workflow

### DIFF
--- a/.github/workflows/auto-beta-release.yml
+++ b/.github/workflows/auto-beta-release.yml
@@ -45,11 +45,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
       
-      - name: Run tests
-        run: npm test
-      
       - name: Build project
         run: npm run build:clean
+      
+      - name: Run tests
+        run: npm test
       
       - name: Get current version
         id: current_version


### PR DESCRIPTION
Quick fix to ensure the project is built before running tests in the auto-beta-release workflow.

The integration tests require the dist/ directory to exist, so we need to build first.

🤖 Generated with [Claude Code](https://claude.ai/code)