### PR TITLE
fix: ensure auto-beta-publish runs on all master merges

### DIFF
--- a/.github/workflows/auto-beta-publish.yml
+++ b/.github/workflows/auto-beta-publish.yml
@@ -15,18 +15,24 @@ jobs:
     # Skip if:
     # - Commit message contains [skip ci]
     # - It's a version commit
-    # - It's not from a PR merge
+    # - It's a release commit
     if: |
       !contains(github.event.head_commit.message, '[skip ci]') &&
       !contains(github.event.head_commit.message, 'chore: version packages') &&
       !contains(github.event.head_commit.message, 'chore(release):') &&
-      !contains(github.event.head_commit.message, 'Version Packages') &&
-      (contains(github.event.head_commit.message, '(#') || github.event.head_commit.author.name == 'github-actions[bot]')
+      !contains(github.event.head_commit.message, 'Version Packages')
     permissions:
       contents: write
       packages: write
       id-token: write
     steps:
+      - name: Debug - Show event info
+        run: |
+          echo "Commit message: ${{ github.event.head_commit.message }}"
+          echo "Author: ${{ github.event.head_commit.author.name }}"
+          echo "Event name: ${{ github.event_name }}"
+          echo "Branch: ${{ github.ref }}"
+          
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:

--- a/scripts/release-prod.sh
+++ b/scripts/release-prod.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # Script to trigger a production release
+# This creates a Version Packages PR that, when merged, publishes to npm
 
 echo "🚀 Claude GWT Production Release Tool"
 echo "===================================="


### PR DESCRIPTION
## Summary
- Remove PR merge requirement from auto-beta-publish workflow that was preventing it from running
- Add debug output to help verify workflow is triggered correctly
- Minor update to release script comment

## Problem
The auto-beta-publish workflow was not running after PR merges because it had a condition that required either:
- Commit message to contain `(#` (indicating a PR merge)
- OR commit author to be `github-actions[bot]`

Since squash merges don't always include the PR number in the commit message, the workflow was being skipped.

## Solution
Remove the PR merge requirement entirely. The workflow will now run on ALL pushes to master except for:
- Commits with `[skip ci]`
- Version commits (`chore: version packages`)
- Release commits (`chore(release):`)

## Test plan
After merging this PR, the auto-beta-publish workflow should:
1. Run automatically (check Actions tab)
2. Show debug output with commit info
3. Create a new beta version
4. Publish to npm with beta tag
5. Create a GitHub pre-release

🤖 Generated with [Claude Code](https://claude.ai/code)