### PR TITLE
fix: add GITHUB_TOKEN to changeset version step

### DIFF
--- a/.github/workflows/auto-beta-publish.yml
+++ b/.github/workflows/auto-beta-publish.yml
@@ -67,6 +67,8 @@ jobs:
           # Get the new version
           NEW_VERSION=$(node -p "require('./package.json').version")
           echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_ENV
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Bump patch version (if no changesets)
         if: steps.changesets-check.outputs.has-changesets == 'false'


### PR DESCRIPTION
The auto-beta-publish workflow failed because changesets needs GITHUB_TOKEN to fetch commit info for changelog generation.

This PR adds the GITHUB_TOKEN environment variable to the changeset version step.