### PR TITLE
fix: make CLI version dynamic from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-gwt",
-  "version": "0.2.3-beta.1",
+  "version": "0.3.0-beta.1751891532",
   "description": "[BETA] A beautiful Git Worktree manager with integrated Claude Code orchestration - Experimental software under active development",
   "type": "module",
   "main": "dist/index.js",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,17 +1,28 @@
 #!/usr/bin/env node
 
 import { Command } from 'commander';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
 import { ClaudeGWTApp } from './ClaudeGWTApp.js';
 import { theme } from './ui/theme.js';
 import { Logger } from '../core/utils/logger.js';
 import type { CLIOptions } from '../types/index.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// Read version from package.json dynamically
+const packageJsonPath = join(__dirname, '../../../package.json');
+const packageJsonContent = readFileSync(packageJsonPath, 'utf-8');
+const packageJson = JSON.parse(packageJsonContent) as { version: string };
 
 const program = new Command();
 
 program
   .name('claude-gwt')
   .description('Git Worktree Manager with Claude Code Orchestration')
-  .version('0.2.3-beta.1');
+  .version(packageJson.version);
 
 // Main command
 program

--- a/tests/unit/cli/version.test.ts
+++ b/tests/unit/cli/version.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { execSync } from 'child_process';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('CLI Version', () => {
+  it('should match package.json version', () => {
+    // Read package.json version
+    const packageJsonPath = join(process.cwd(), 'package.json');
+    const packageJsonContent = readFileSync(packageJsonPath, 'utf-8');
+    const packageJson = JSON.parse(packageJsonContent) as { version: string };
+    const expectedVersion = packageJson.version;
+
+    // Get CLI version
+    const cliPath = join(process.cwd(), 'dist', 'src', 'cli', 'index.js');
+    const cliVersion = execSync(`node ${cliPath} --version`, { encoding: 'utf-8' }).trim();
+
+    // Verify they match
+    expect(cliVersion).toBe(expectedVersion);
+  });
+
+  it('should display version with --version flag', () => {
+    const cliPath = join(process.cwd(), 'dist', 'src', 'cli', 'index.js');
+    const output = execSync(`node ${cliPath} --version`, { encoding: 'utf-8' }).trim();
+
+    // Should be a valid semver format
+    expect(output).toMatch(/^\d+\.\d+\.\d+(-\S+)?$/);
+  });
+
+  it('should display version with -V flag', () => {
+    const cliPath = join(process.cwd(), 'dist', 'src', 'cli', 'index.js');
+    const output = execSync(`node ${cliPath} -V`, { encoding: 'utf-8' }).trim();
+
+    // Should be a valid semver format
+    expect(output).toMatch(/^\d+\.\d+\.\d+(-\S+)?$/);
+  });
+});


### PR DESCRIPTION
## Summary
Fixes the issue where `claude-gwt --version` always showed `0.2.3-beta.1` regardless of the actual installed version.

## Problem
When installing `claude-gwt@0.3.0-beta.1751891532`, the CLI would still report version `0.2.3-beta.1` because the version was hardcoded in the source.

## Solution
- CLI now reads version dynamically from package.json at runtime
- Added proper TypeScript types to avoid linting errors
- Added comprehensive tests to ensure CLI version always matches package.json

## Test
After this fix:
```bash
npm install -g claude-gwt@0.3.0-beta.1751891532
claude-gwt --version  # Now shows: 0.3.0-beta.1751891532
```

## Tests Added
- Verify CLI version matches package.json
- Test --version flag
- Test -V flag

🤖 Generated with [Claude Code](https://claude.ai/code)